### PR TITLE
Add Plausible analytics

### DIFF
--- a/apps/www/src/components/Analytics.astro
+++ b/apps/www/src/components/Analytics.astro
@@ -1,0 +1,6 @@
+<script
+  is:inline
+  defer
+  data-domain="peetzweg.com"
+  src="https://analytics.drdrip.xyz/js/script.file-downloads.outbound-links.js"
+></script>

--- a/apps/www/src/layouts/Layout.astro
+++ b/apps/www/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ export interface Props {
 }
 import '@fontsource/noto-sans-mono';
 import '@fontsource/noto-sans-mono/600.css';
+import Analytics from '../components/Analytics.astro';
 
 const { title } = Astro.props;
 ---
@@ -21,6 +22,7 @@ const { title } = Astro.props;
     />
     <meta name="keywords" content="developer, profile, resume" />
     <title>{title}</title>
+    <Analytics />
   </head>
 
   <body>

--- a/apps/www/src/layouts/LinksLayout.astro
+++ b/apps/www/src/layouts/LinksLayout.astro
@@ -2,6 +2,7 @@
 const { title } = Astro.props;
 
 import 'latex.css';
+import Analytics from '../components/Analytics.astro';
 ---
 
 <!doctype html>
@@ -12,6 +13,7 @@ import 'latex.css';
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
+    <Analytics />
   </head>
   <body>
     <main>

--- a/apps/www/src/layouts/PostLayout.astro
+++ b/apps/www/src/layouts/PostLayout.astro
@@ -2,11 +2,13 @@
 const { content } = Astro.props;
 
 import 'latex.css';
+import Analytics from '../components/Analytics.astro';
 ---
 
 <html>
   <head>
     <title>{content.title}</title>
+    <Analytics />
   </head>
   <body>
     <main>

--- a/apps/www/src/layouts/TocLayout.astro
+++ b/apps/www/src/layouts/TocLayout.astro
@@ -3,6 +3,7 @@ export interface Props {
   title: string;
 }
 import 'latex.css';
+import Analytics from '../components/Analytics.astro';
 const { title } = Astro.props;
 ---
 
@@ -10,6 +11,7 @@ const { title } = Astro.props;
   <head>
 
     <title>{title}</title>
+    <Analytics />
   </head>
   <body>
 


### PR DESCRIPTION
Adds the self-hosted Plausible tracking snippet (analytics.drdrip.xyz, with file-downloads and outbound-links extensions) to the site.

**Why:** Get visitor analytics for peetzweg.com.

**How:** New shared `Analytics.astro` component with the script tagged `is:inline` so Astro doesn't bundle it, included in the `<head>` of all four layouts. Verified via a local build that all 14 generated pages contain the snippet unchanged.